### PR TITLE
build: update notion-update-page to 1.1.12

### DIFF
--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -41,7 +41,7 @@ jobs:
           DEFAULT_BUMP: patch
           INITIAL_VERSION: 1.0.0
       - name: Update Notion property
-        uses: szenius/notion-update-page@1.1.4
+        uses: szenius/notion-update-page@1.1.12
         with:
           gh-username: "szenius"
           gh-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/on_master.yml
+++ b/.github/workflows/on_master.yml
@@ -48,3 +48,5 @@ jobs:
           notion-key: ${{ secrets.NOTION_KEY }}
           notion-property-name: "Version Tag"
           notion-update-value: "${{ steps.version.outputs.new_tag }}"
+          notion-property-type: "multi_select"
+          existing-value: "append"


### PR DESCRIPTION
[Notion link](https://www.notion.so/szenius/Automate-start-of-Sprint-90a101791ed645d892e61215bd1df5bf)

This PR upgrades notion-update-page to 1.1.12, and updates the version tag to `multi_select` to allow appending of multiple version tags.
