### PR TITLE
feat: check if story has Status when filtering ongoing stories

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,8 +127,9 @@ const countPointsLeftInSprint = async (
   });
   const sprintStories = response.results;
   const ongoingStories = sprintStories.filter(
-    (item) =>
-      !new RegExp(statusExclude).test(item.properties.Status.select.name)
+    (story) =>
+      story.properties.Status.select &&
+      !new RegExp(statusExclude).test(story.properties.Status.select.name)
   );
   return ongoingStories.reduce((accum, item) => {
     if (item.properties[estimateProp]) {


### PR DESCRIPTION
This PR adds:

- When filtering ongoing stories, we check if each story has a `Status.select` field.

This was added because the GitHub action was failing while trying to fetch the `Status.select.name` value of a story with a blank `Status.select` field, which throws an error.

**Co-author:** @whoiskai